### PR TITLE
Fix license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "name": "hacceuee",
         "url": "https://github.com/hacceuee/s3-pixel-icons"
     },
-    "license": "CC BY-NC-ND 4.0",
+    "license": "CC-BY-NC-4.0",
     "bugs": {
         "url": "https://github.com/hacceuee/s3-pixel-icons/issues"
     },


### PR DESCRIPTION
Clear inconsistencies with the LICENSE file and specify the [correct SPDX Identifier](https://spdx.org/licenses/).