### PR TITLE
Optimize PNG files with pngcrush

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,11 @@ jobs:
               with:
                   node-version: 16
                   registry-url: https://registry.npmjs.org
+            - name: optimize png files
+              run: |
+                sudo apt update -y
+                sudo apt install -y pngcrush
+                find . -type f -name '*.png' -print0 | xargs -0 -n 1 pngcrush -ow -rem alla -l 9
             - name: publish
               run: npm publish --access public
               env:


### PR DESCRIPTION
Optimize PNG files to reduce file size when publishing to NPM.
With this patch, you can deploy image files that are exactly the same on the screen, but with about half the file size.

Before the patch:
```
npm notice package size:  310.8 kB                                
npm notice unpacked size: 336.8 kB                                
```

After the patch:
```
npm notice package size:  145.5 kB
npm notice unpacked size: 153.6 kB
```

Technical Details:
Due to its specifications, a PNG file can represent the exact same image data in multiple ways.
There are probably a thousand combinations of the major representations, but it would take too long to try them all, so image processing applications (e.g., photoshop and mspaint) usually try one or a few different combinations to create a file.
`pngcrush` tries those combinations and looks for the smallest possible combination.
Therefore, the smaller size caused by this patch is not due to degradation, not like JPEG.

In addition, pngcrush is set to remove unnecessary [chunks](https://en.wikipedia.org/wiki/PNG#%22Chunks%22_within_the_file).
This removes trivial information, such as the name of the software used to create the file, for example, and saves dozens of bytes.