### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
-                  node-version: 16
+                  node-version: 20
                   registry-url: https://registry.npmjs.org
             - name: optimize png files
               run: |

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *.psd
-/Custom Art/
+/.github/
 /Archived Images/
+/Custom Art/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hacceuee/s3-pixel-icons",
-    "version": "2.3.1",
+    "version": "2.3.2",
     "description": "s3 Pixel Icons",
     "repository": {
         "type": "git",


### PR DESCRIPTION
- Update Node.js 16 to 20; suppress deprecated warnings
- Remove `.github` directory from published package

I have not actually tested these changes, unfortunately.
I believe it will work probably 😃 